### PR TITLE
Add patch file for Fantasy Creatures Reborn

### DIFF
--- a/mods/xskills/assets/xskills/patches/combat/fantasycreaturesupdate.json
+++ b/mods/xskills/assets/xskills/patches/combat/fantasycreaturesupdate.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "fantasycreaturesupdate:entities/land/cavegoblin",
+    "file": "fantasycreatures:entities/land/cavegoblin",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -10,7 +10,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/cavegoblin",
+    "file": "fantasycreatures:entities/land/cavegoblin",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -20,7 +20,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/dragon",
+    "file": "fantasycreatures:entities/land/dragon",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -30,7 +30,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/dragon",
+    "file": "fantasycreatures:entities/land/dragon",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -40,7 +40,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/dragon-flying",
+    "file": "fantasycreatures:entities/land/dragon-flying",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -50,7 +50,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/dragon-flying",
+    "file": "fantasycreatures:entities/land/dragon-flying",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -60,7 +60,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/ent-shepherd",
+    "file": "fantasycreatures:entities/land/ent-shepherd",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -70,7 +70,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/ent-shepherd",
+    "file": "fantasycreatures:entities/land/ent-shepherd",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -80,7 +80,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/lonehuntergoblin",
+    "file": "fantasycreatures:entities/land/lonehuntergoblin",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -90,7 +90,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/lonehuntergoblin",
+    "file": "fantasycreatures:entities/land/lonehuntergoblin",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -100,7 +100,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/ork",
+    "file": "fantasycreatures:entities/land/ork",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -110,7 +110,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/ork",
+    "file": "fantasycreatures:entities/land/ork",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -120,7 +120,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/skeleton",
+    "file": "fantasycreatures:entities/land/skeleton",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -130,7 +130,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/skeleton",
+    "file": "fantasycreatures:entities/land/skeleton",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -140,47 +140,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/skeletonblkgrd",
-    "op": "addmerge",
-    "path": "/client/behaviors/-",
-    "value": {
-      "code": "XSkillsEntity",
-      "xp": 3.0
-    },
-    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
-  },
-  {
-    "file": "fantasycreaturesupdate:entities/land/skeletonblkgrd",
-    "op": "addmerge",
-    "path": "/server/behaviors/-",
-    "value": {
-      "code": "XSkillsEntity",
-      "xp": 3.0
-    },
-    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
-  },
-  {
-    "file": "fantasycreaturesupdate:entities/land/skeleton-deserter",
-    "op": "addmerge",
-    "path": "/client/behaviors/-",
-    "value": {
-      "code": "XSkillsEntity",
-      "xp": 1.0
-    },
-    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
-  },
-  {
-    "file": "fantasycreaturesupdate:entities/land/skeleton-deserter",
-    "op": "addmerge",
-    "path": "/server/behaviors/-",
-    "value": {
-      "code": "XSkillsEntity",
-      "xp": 1.0
-    },
-    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
-  },
-  {
-    "file": "fantasycreaturesupdate:entities/land/slime",
+    "file": "fantasycreatures:entities/land/skeletonblkgrd",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -190,7 +150,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/slime",
+    "file": "fantasycreatures:entities/land/skeletonblkgrd",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -200,7 +160,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/surface_skeleton",
+    "file": "fantasycreatures:entities/land/skeleton-deserter",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -210,7 +170,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/surface_skeleton",
+    "file": "fantasycreatures:entities/land/skeleton-deserter",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -220,7 +180,27 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/surfacegoblin",
+    "file": "fantasycreatures:entities/land/slime",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 3.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreatures:entities/land/slime",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 3.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreatures:entities/land/surface_skeleton",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -230,7 +210,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/surfacegoblin",
+    "file": "fantasycreatures:entities/land/surface_skeleton",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {
@@ -240,7 +220,27 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/treant",
+    "file": "fantasycreatures:entities/land/surfacegoblin",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreatures:entities/land/surfacegoblin",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreatures:entities/land/treant",
     "op": "addmerge",
     "path": "/client/behaviors/-",
     "value": {
@@ -250,7 +250,7 @@
     "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
   },
   {
-    "file": "fantasycreaturesupdate:entities/land/treant",
+    "file": "fantasycreatures:entities/land/treant",
     "op": "addmerge",
     "path": "/server/behaviors/-",
     "value": {

--- a/mods/xskills/assets/xskills/patches/combat/fantasycreaturesupdate.json
+++ b/mods/xskills/assets/xskills/patches/combat/fantasycreaturesupdate.json
@@ -1,0 +1,262 @@
+[
+  {
+    "file": "fantasycreaturesupdate:entities/land/cavegoblin",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/cavegoblin",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/dragon",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 50.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/dragon",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 50.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/dragon-flying",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 50.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/dragon-flying",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 50.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/ent-shepherd",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 20.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/ent-shepherd",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 20.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/lonehuntergoblin",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/lonehuntergoblin",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/ork",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/ork",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/skeleton",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/skeleton",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/skeletonblkgrd",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 3.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/skeletonblkgrd",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 3.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/skeleton-deserter",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/skeleton-deserter",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/slime",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 3.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/slime",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 3.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/surface_skeleton",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/surface_skeleton",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/surfacegoblin",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/surfacegoblin",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 1.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/treant",
+    "op": "addmerge",
+    "path": "/client/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 50.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  },
+  {
+    "file": "fantasycreaturesupdate:entities/land/treant",
+    "op": "addmerge",
+    "path": "/server/behaviors/-",
+    "value": {
+      "code": "XSkillsEntity",
+      "xp": 50.0
+    },
+    "dependsOn": [ { "modid": "fantasycreaturesupdate" } ]
+  }
+]


### PR DESCRIPTION
Fantasy Creatures Reborn is a new 1.21 version of Fantasy Creatures and has a different modid from the original. This adds the patchfile to fix that.